### PR TITLE
Ensure dispatchable events

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ public function handle(SnsMessageReceived $event)
 ```
 The message content will always be a string. You are responsible for any deserialization or other steps required to interpret the message content.
 
+### Dispatching specific events for specific ARNs
+It is possible to map individual event classes to individual ARNs. The map is stored in the sns-handler.php config file (ensure this is published if it does not exist in your project). You can map either subscription events or message events in the following format:
+```php
+ 'message-events' => [
+    SnsMessageAlphaReceived::class => ['arn:aws:sns:us-west-2:123456789012:AlphaTopic'],
+    SnsMessageBetaReceived::class => ['arn:aws:sns:us-west-2:123456789012:BetaTopic', 'arn:aws:sns:us-west-2:123456789012:GammaTopic'],
+    SnsMessageReceived::class => ['*'],
+ ];
+```
+Note that the map is parsed in order, so the first match found in the list will be the class dispatched.
+Note that a default event class is not required, but if a matching event cannot be found in the map, a 404 will be returned if a message is sent using that ARN.
 ## Write a feature test to test the expected SNS feature
 The ReceivesSnsMessagesTrait facilitates testing. Use the trait in your test
 
@@ -72,6 +83,11 @@ You can add your serialized message in the message field. Note that manually POS
 ## How to subscribe your endpoint in AWS
 This package adds a route to your application for incoming SNS requests. Note that because this is an api route, any API middleware you have applied in your application will affect this route. The route will be `{Your application's base URL}/api/sns/message`.
 [Follow these instructions to subscribe your endpoint using HTTPS](https://docs.aws.amazon.com/sns/latest/dg/sns-http-https-endpoint-as-subscriber.html).
+
+This package is configured to automatically respond to all SNS subscription requests sent to its endpoint. This can be disabled by adding the following to your .env file:
+```
+AUTO_CONFIRM_SUBSCRIPTIONS=false
+```
 
 **Note: You will only be able to subscribe your endpoint if it can be reached from the AWS SNS service**
 

--- a/config/sns-handler.php
+++ b/config/sns-handler.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'auto-confirm-subscriptions' => env('AUTO_CONFIRM_SUBSCRIPTIONS', true),
     'validate-sns-messages' => env('VALIDATE_SNS_MESSAGES', true),
     'confirmation-events' => [
         Nipwaayoni\SnsHandler\Events\SnsConfirmationRequestReceived::class => ['*']

--- a/src/SnsBroker.php
+++ b/src/SnsBroker.php
@@ -61,6 +61,10 @@ class SnsBroker
 
             case SnsMessage::SUBSCRIBE_TYPE:
                 $className = $this->getSubscriptionEvent($message->topicArn());
+                if($this->config->get('sns-handler.auto-confirm-subscriptions', true) === false){
+                    Log::info(sprintf('Subscription confirmation event not handled for topic %s with %s because auto-confirm-subscriptions disabled', $message->topicArn(), $className));
+                    return;
+                }
                 $className::dispatch($message);
                 Log::info(sprintf('Dispatched confirmation event for subscription to topic %s with %s', $message->topicArn(), $className));
                 return;

--- a/src/SnsBroker.php
+++ b/src/SnsBroker.php
@@ -73,7 +73,7 @@ class SnsBroker
     /**
      * @param string $arn
      * @return string
-     * @throws SnsUnknownTopicArnException
+     * @throws SnsUnknownTopicArnException|SnsException
      */
     private function getSubscriptionEvent(string $arn): string
     {
@@ -84,7 +84,7 @@ class SnsBroker
     /**
      * @param string $arn
      * @return string
-     * @throws SnsUnknownTopicArnException
+     * @throws SnsUnknownTopicArnException|SnsException
      */
     private function getNotificationEvent(string $arn): string
     {
@@ -96,7 +96,7 @@ class SnsBroker
      * @param string $arn
      * @param array $map
      * @return string
-     * @throws SnsUnknownTopicArnException
+     * @throws SnsUnknownTopicArnException|SnsException
      */
     private function arnMap(string $arn, array $map): string
     {
@@ -106,6 +106,7 @@ class SnsBroker
                 $default = $className;
             }
             if (in_array($arn, $arnList)) {
+                $this->ensureDispatchable($className);
                 return $className;
             }
         }
@@ -115,7 +116,20 @@ class SnsBroker
         }
 
         // TODO ensure class is dispatchable
+        $this->ensureDispatchable($default);
 
         return $default;
+    }
+
+    /**
+     * @param string $className
+     * @throws SnsException
+     */
+    private function ensureDispatchable(string $className): void
+    {
+        if(method_exists($className, 'dispatch')){
+            return;
+        }
+        throw new SnsException('Mapped class is not dispatchable:' . $className);
     }
 }

--- a/src/SnsBroker.php
+++ b/src/SnsBroker.php
@@ -61,7 +61,7 @@ class SnsBroker
 
             case SnsMessage::SUBSCRIBE_TYPE:
                 $className = $this->getSubscriptionEvent($message->topicArn());
-                if($this->config->get('sns-handler.auto-confirm-subscriptions', true) === false){
+                if ($this->config->get('sns-handler.auto-confirm-subscriptions', true) === false) {
                     Log::info(sprintf('Subscription confirmation event not handled for topic %s with %s because auto-confirm-subscriptions disabled', $message->topicArn(), $className));
                     return;
                 }
@@ -131,7 +131,7 @@ class SnsBroker
      */
     private function ensureDispatchable(string $className): void
     {
-        if(method_exists($className, 'dispatch')){
+        if (method_exists($className, 'dispatch')) {
             return;
         }
         throw new SnsException('Mapped class is not dispatchable:' . $className);

--- a/tests/Events/SnsMessageNotDispatchable.php
+++ b/tests/Events/SnsMessageNotDispatchable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Nipwaayoni\Tests\SnsHandler\Events;
+
+class SnsMessageNotDispatchable
+{
+
+}

--- a/tests/Events/SnsMessageNotDispatchable.php
+++ b/tests/Events/SnsMessageNotDispatchable.php
@@ -4,5 +4,4 @@ namespace Nipwaayoni\Tests\SnsHandler\Events;
 
 class SnsMessageNotDispatchable
 {
-
 }

--- a/tests/Unit/SnsBrokerTest.php
+++ b/tests/Unit/SnsBrokerTest.php
@@ -274,5 +274,4 @@ class SnsBrokerTest extends TestCase
 
         Event::assertNotDispatched(SnsConfirmationRequestReceived::class);
     }
-
 }

--- a/tests/Unit/SnsBrokerTest.php
+++ b/tests/Unit/SnsBrokerTest.php
@@ -258,4 +258,21 @@ class SnsBrokerTest extends TestCase
         Event::assertNotDispatched(SnsMessageReceived::class);
     }
 
+    public function testDoesNotAutoConfirmSubscriptionsWhenDisabled(): void
+    {
+        $this->configValues['auto-confirm-subscriptions'] = false;
+
+        $request = $this->createMock(SnsHttpRequest::class);
+        $request->expects($this->once())->method('jsonContent')
+            ->willReturn($this->makeSnsMessageJson([
+                'Type' => SnsMessage::SUBSCRIBE_TYPE,
+                'SubscribeURL' => 'https://aws.amazon.com/subscribe/123',
+                'TopicArn' => 'arn:aws:sns:us-west-2:123456789012:AlphaTopic'
+            ]));
+
+        $this->broker->handleRequest($request);
+
+        Event::assertNotDispatched(SnsConfirmationRequestReceived::class);
+    }
+
 }


### PR DESCRIPTION
Closes #7 
Closes #8 
Closes #9 

Added a check that events are dispatchable and made it possible to disable auto-subscription of new topics, then updated the related documentation.